### PR TITLE
fix: add build artifacts to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# build artifacts, if built while in `./source`
+.sconsign.dblite
+config.log
+.sconf_temp
+*.a
+*.o
+moc_*.cc
+source/gemc


### PR DESCRIPTION
When building (`scons`) while the working directory is `./source`, several build artifacts may be created locally. This PR adds them to the `.gitignore`.