### PR TITLE
ci: `cancel-in-progress` for every new commit

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}  # PR triggers only
+  group: ${{ github.workflow }} # all triggers of this workflow (since pushing to `main` is common)
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Since pushing directly to `main` is common here, and pull requests are not, let's enable `cancel-in-progress` for all new commits.