### PR TITLE
test: override `clas12-validation` highest-tag feature

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   validation:
-    uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@main
+    uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@lock-5.4


### PR DESCRIPTION
### do not merge

testing https://github.com/JeffersonLab/clas12-validation/pull/68 to make sure the correct ref of this caller repo is used.