### PR TITLE
Fix: WF for AHDC is not fill.

### DIFF
--- a/source/hitprocess/clas12/alert/ahdc_hitprocess.cc
+++ b/source/hitprocess/clas12/alert/ahdc_hitprocess.cc
@@ -100,7 +100,7 @@ map<string, double> ahdc_HitProcess::integrateDgt(MHit* aHit, int hitn) {
 	dgtz["WF_timestamp"] = 0;
 
 	for(unsigned t=0; t<30; t++) {
-		string dname = "WF_s" + to_string(t+1);
+		string dname = "wf_s" + to_string(t+1);
 		dgtz[dname] = Signal->GetDgtz().at(t);
 	}
 	delete Signal;

--- a/source/output/hipoSchemas.cc
+++ b/source/output/hipoSchemas.cc
@@ -97,7 +97,7 @@ HipoSchema::HipoSchema() {
 
 
     // detectors
-    alertAhdcADCSchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, timestamp/L");
+    alertAhdcADCSchema.parse("sector/B, layer/B, component/S, order/B, ADC/I, time/F, ped/S, integral/I, windex/S, timestamp/L, leadingEdgeTime/F, timeOverThreshold/F, constantFractionTime/F");
     alertAhdcTDCSchema.parse("sector/B, layer/B, component/S, order/B, TDC/I, ped/S");
     std::string wf_string = "sector/B, layer/B, component/S, order/B, timestamp/L";
     for (int itr=0; itr<30; itr++){

--- a/source/output/hipo_output.cc
+++ b/source/output/hipo_output.cc
@@ -792,7 +792,7 @@ void hipo_output::writeG4DgtIntegrated(outputContainer *output, vector <hitOutpu
                                 detectorWFBank.putLong("timestamp", nh, thisVar.second);
                             } else {
                                 // all other ADC vars must begin with "ADC_"
-                                if (bname.find("WF_s") == 0) {
+                                if (bname.find("wf_s") == 0) {
                                     // sample number is the string following "WF_s" converted to int
                                     int sample_value = stoi(bname.substr(4));
                                     string wfname = "s" + to_string(sample_value);

--- a/source/output/hipo_output.cc
+++ b/source/output/hipo_output.cc
@@ -794,7 +794,7 @@ void hipo_output::writeG4DgtIntegrated(outputContainer *output, vector <hitOutpu
                                 // all other ADC vars must begin with "ADC_"
                                 if (bname.find("WF_s") == 0) {
                                     // sample number is the string following "WF_s" converted to int
-                                    int sample_value = stoi(bname.substr(7));
+                                    int sample_value = stoi(bname.substr(4));
                                     string wfname = "s" + to_string(sample_value);
                                     detectorWFBank.putShort(wfname.c_str(), nh, thisVar.second);
                                 }


### PR DESCRIPTION
The s variable in WF bank for the AHDC is not fill (0 everywhere).
 
* Updated the waveform sample variable prefix from `WF_s` to `wf_s` in `ahdc_HitProcess::integrateDgt` and `hipo_output::writeG4DgtIntegrated`. 
* Extended the `alertAhdcADCSchema` to include additional fields: `windex`, `leadingEdgeTime`, `timeOverThreshold`, and `constantFractionTime` to match COATJAVA.

I don't know why the wf_s need to be lower case. 