### PR TITLE
Fix: Change name of the waveform bank name AHDC::wf for the signal fr…

### DIFF
--- a/source/hitprocess/clas12/alert/ahdc_hitprocess.cc
+++ b/source/hitprocess/clas12/alert/ahdc_hitprocess.cc
@@ -100,7 +100,7 @@ map<string, double> ahdc_HitProcess::integrateDgt(MHit* aHit, int hitn) {
 	dgtz["WF_timestamp"] = 0;
 
 	for(unsigned t=0; t<30; t++) {
-		string dname = "WF_s" + to_string(t+1);
+		string dname = "wf_s" + to_string(t+1);
 		dgtz[dname] = Signal->GetDgtz().at(t);
 	}
 	delete Signal;

--- a/source/output/hipo_output.cc
+++ b/source/output/hipo_output.cc
@@ -792,9 +792,9 @@ void hipo_output::writeG4DgtIntegrated(outputContainer *output, vector <hitOutpu
                                 detectorWFBank.putLong("timestamp", nh, thisVar.second);
                             } else {
                                 // all other ADC vars must begin with "ADC_"
-                                if (bname.find("WF_s") == 0) {
+                                if (bname.find("wf_s") == 0) {
                                     // sample number is the string following "WF_s" converted to int
-                                    int sample_value = stoi(bname.substr(7));
+                                    int sample_value = stoi(bname.substr(4));
                                     string wfname = "s" + to_string(sample_value);
                                     detectorWFBank.putShort(wfname.c_str(), nh, thisVar.second);
                                 }


### PR DESCRIPTION
…om WF to wf

The wf_sX variable in the AHDC::wf need to be lowercase. 

I have update the pull request by removing the part that change the schema. 
Now, I have only change the name of the wf_sX variable to match what is use in the geometry_source/alert/ahdc/bank.pl line 50: my $entry = "wf_s$itr"
and the ahdc_bank.txt:                   ahdc  |               wf_s1  |                                      ADC sample 1  |   15   |                  Di 