### PR TITLE
test: trigger `clas12-validation` after `sqlite` change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The clas12Tags repository
+# The clas12Tags repository 
 
 The `clas12Tags` repository serves as the simulation resource for the CLAS12 experiments 
 at Jefferson Lab, providing:  


### PR DESCRIPTION
this just tests if `clas12-validation` still runs okay after https://github.com/JeffersonLab/clas12-validation/pull/182 was merged, since `clas12Tags` triggers GEMC rebuilds

**do not merge**