### PR TITLE
Make z positions consistent for the RICH

### DIFF
--- a/experiments/clas12/rich/cad/cad_rgc_summer2022.gxml
+++ b/experiments/clas12/rich/cad/cad_rgc_summer2022.gxml
@@ -1,5 +1,5 @@
 <gxml>
-	<volume name="AaRICH_m1" color="444444" material="Air_Opt" position="0*cm 0*cm 5*cm" rotation="0 0 0*deg" mother="root" />
+	<volume name="AaRICH_m1" color="444444" material="Air_Opt" position="0*cm 0*cm 0*cm" rotation="0 0 0*deg" mother="root" />
 	<volume name="TedlarWrapping_m1" color="444444" material="G4_AIR" position="0*cm 0*cm 0*cm" rotation="0 0 0" mother="AaRICH_m1" />
 	<volume name="Aluminum_m1" color="4444ff" material="G4_Al" position="0*cm 0*cm 0*cm" rotation="0 0 0" mother="AaRICH_m1" />
 	<volume name="CFRP_m1" color="44ff44" material="CarbonFiber" position="0*cm 0*cm 0*cm" rotation="0 0 0" mother="AaRICH_m1" />
@@ -113,7 +113,7 @@
 	<volume name="Layer_301_component_5_m1" color="cc99ff" material="G4_Pyrex_Glass" position="0*cm 0*cm 0*cm" rotation="0 0 0" mother="AaRICH_m1" sensitivity="mirror: rich_m1_mirror_planar_comp_5" hitType="mirror" identifiers="module manual 5" />
 	<volume name="Layer_301_component_6_m1" color="cc99ff" material="G4_Pyrex_Glass" position="0*cm 0*cm 0*cm" rotation="0 0 0" mother="AaRICH_m1" sensitivity="mirror: rich_m1_mirror_planar_comp_6" hitType="mirror" identifiers="module manual 6" />
 	<volume name="Layer_301_component_7_m1" color="cc99ff" material="G4_Pyrex_Glass" position="0*cm 0*cm 0*cm" rotation="0 0 0" mother="AaRICH_m1" sensitivity="mirror: rich_m1_mirror_planar_comp_7" hitType="mirror" identifiers="module manual 7" />
-	<volume name="AaRICH_m2" color="444444" material="Air_Opt" position="0*cm 0*cm 5*cm" rotation="0 0 180*deg" mother="root" />
+	<volume name="AaRICH_m2" color="444444" material="Air_Opt" position="0*cm 0*cm 0*cm" rotation="0 0 180*deg" mother="root" />
 	<volume name="TedlarWrapping_m2" color="444444" material="G4_AIR" position="0*cm 0*cm 0*cm" rotation="0 0 0" mother="AaRICH_m2" />
 	<volume name="Aluminum_m2" color="4444ff" material="G4_Al" position="0*cm 0*cm 0*cm" rotation="0 0 0" mother="AaRICH_m2" />
 	<volume name="CFRP_m2" color="44ff44" material="CarbonFiber" position="0*cm 0*cm 0*cm" rotation="0 0 0" mother="AaRICH_m2" />

--- a/geometry_source/rich/geometry.pl
+++ b/geometry_source/rich/geometry.pl
@@ -85,7 +85,7 @@ sub build_MESH {
         }
         $detector{"pos"} = $positions->{$vname};
         if ($mesh eq "RICH_s4" and ($variation eq "rga_fall2018" or $variation eq "rgc_summer2022")) {
-            $detector{"pos"} = "0*cm 0*cm 5*cm";
+            $detector{"pos"} = "0*cm 0*cm 0*cm";
         }
         #rotate mesh for sector 1 180 deg. around z
         $detector{"rotation"} = $rotations->{$vname};


### PR DESCRIPTION
Some time ago, it was requested that we add a 5cm shift in z to the RICH in gemc. However, it does not seem that this is necessary for the RICH response in simulation to correspond to the RICH information in data. Additionally, at some point the 5cm shift was removed from the RGA geometry but kept in the rgc geometry (difference between `cad_rgc_summer2022.gxml` and `cad_rga_spring2018.gxml`).
Since we have already calibrated the RICH for the RGA simulation campaign **without** the 5cm shift, we propose to keep the RGA RICH geometry as it is (in nominal positions), and instead simply remove this 5cm shift from the RGC RICH geometry as well. 
As of now this would only change the geometry of the RICH for the RGC variation, and should not have any impact on the RGA simulation campaign. However, this change should certainly be added for `geometry.pl` to ensure that the next time the RICH geometry is compiled, the RICH is still in the nominal position (no shift) for RGA.