### PR TITLE
Fix: ALERT helium target gas material

### DIFF
--- a/geometry_source/targets/alert.pl
+++ b/geometry_source/targets/alert.pl
@@ -179,7 +179,7 @@ sub build_alert_mats {
         $mat{"description"} = "5.6 atm helium gas";
         $mat{"density"} = "0.000931"; # in g/cm3
         $mat{"ncomponents"} = "1";
-        $mat{"components"} = "deuteriumGas 1";
+        $mat{"components"} = "He 1";
         print_mat(\%configuration, \%mat);
     }
 


### PR DESCRIPTION
The rgl_spring2025_He material definition incorrectly used deuteriumGas as its component.

This changes the component to He while retaining the existing helium material name and density.